### PR TITLE
Standardize coordinate schemes

### DIFF
--- a/zoloto/coords.py
+++ b/zoloto/coords.py
@@ -132,7 +132,7 @@ class Orientation:
         # and rotate so that 0 yaw is facing the camera
         quaternion = Quaternion(
             initial_rotation.w,
-            initial_rotation.z,
+            -initial_rotation.z,
             -initial_rotation.x,
             initial_rotation.y,
         ) * self.__MARKER_ORIENTATION_CORRECTION

--- a/zoloto/coords.py
+++ b/zoloto/coords.py
@@ -1,3 +1,10 @@
+"""
+Contructs to convert the R and t vectors into other coordinate systems.
+
+Setting the environment variable ZOLOTO_LEGACY_AXIS uses the axis that were
+used up to version 0.9.0. Otherwise the conventional right-handed axis is used
+where x is forward, y is left and z is upward.
+"""
 from __future__ import annotations
 
 import os

--- a/zoloto/coords.py
+++ b/zoloto/coords.py
@@ -27,8 +27,21 @@ class PixelCoordinates(NamedTuple):
 
 class CartesianCoordinates(NamedTuple):
     """
-    Cartesian coordinates, rotated on their side.
+    Conventional:
+    The X axis extends directly away from the camera. Zero is at the camera.
+    Increasing values indicate greater distance from the camera.
 
+    The Y axis is horizontal relative to the camera's perspective, i.e: right
+    to left within the frame of the image. Zero is at the centre of the image.
+    Increasing values indicate greater distance to the left.
+
+    The Z axis is vertical relative to the camera's perspective, i.e: down to
+    up within the frame of the image. Zero is at the centre of the image.
+    Increasing values indicate greater distance above the centre of the image.
+
+    More information: https://w.wiki/5zbE
+
+    Legacy:
     The X axis is horizontal relative to the camera's perspective, i.e: left &
     right within the frame of the image. Zero is at the centre of the image.
     Increasing values indicate greater distance to the right.
@@ -51,6 +64,17 @@ class CartesianCoordinates(NamedTuple):
     x: float
     y: float
     z: float
+
+    @classmethod
+    def from_tvec(cls, x: float, y: float, z: float) -> CartesianCoordinates:
+        if os.environ.get('ZOLOTO_LEGACY_AXIS'):
+            return CartesianCoordinates(
+                x=x, y=y, z=z,
+            )
+        else:
+            return CartesianCoordinates(
+                x=z, y=-x, z=-y,
+            )
 
 
 class SphericalCoordinates(NamedTuple):
@@ -110,7 +134,7 @@ RotationMatrix = Tuple[ThreeTuple, ThreeTuple, ThreeTuple]
 class Orientation:
     """The orientation of an object in 3-D space."""
 
-    # The rotation so that (0, 0, 0) in yaw_pitch_roll is a marker facing
+    # The rotation so that (0, 0, 0) in _yaw_pitch_roll is a marker facing
     # directly at the camera, not away
     __MARKER_ORIENTATION_CORRECTION = Quaternion(matrix=np.array([
         [-1, 0, 0],

--- a/zoloto/coords.py
+++ b/zoloto/coords.py
@@ -120,7 +120,7 @@ class SphericalCoordinates(NamedTuple):
         if os.environ.get('ZOLOTO_LEGACY_AXIS'):
             return self.phi - (math.pi / 2)
         else:
-            raise AttributeError("Rotation around this axis is not used")
+            raise AttributeError("That axis is not available in the selected coordinate system.")
 
     @property
     def rot_y(self) -> float:
@@ -153,7 +153,7 @@ class SphericalCoordinates(NamedTuple):
         Legacy: This is unused.
         """
         if os.environ.get('ZOLOTO_LEGACY_AXIS'):
-            raise AttributeError("Rotation around this axis is not used")
+            raise AttributeError("That axis is not available in the selected coordinate system.")
         else:
             return self.theta
 

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -70,7 +70,7 @@ class BaseMarker(ABC):
 
     @cached_property
     def spherical(self) -> SphericalCoordinates:
-        return SphericalCoordinates.from_cartesian(self.cartesian)
+        return SphericalCoordinates.from_tvec(*self._tvec.tolist())
 
     @property
     def cartesian(self) -> CartesianCoordinates:

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -74,7 +74,7 @@ class BaseMarker(ABC):
 
     @property
     def cartesian(self) -> CartesianCoordinates:
-        return CartesianCoordinates(*self._tvec.tolist())
+        return CartesianCoordinates.from_tvec(*self._tvec.tolist())
 
     @property
     def _rvec(self) -> NDArray:

--- a/zoloto/marker.py
+++ b/zoloto/marker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
+import numpy as np
 from cached_property import cached_property
 from cv2 import aruco
 from numpy.typing import NDArray
@@ -56,11 +57,8 @@ class BaseMarker(ABC):
 
     @cached_property
     def pixel_centre(self) -> PixelCoordinates:
-        tl, _, br, _ = self.pixel_corners
-        return PixelCoordinates(
-            x=tl.x + (self.size / 2) - 1,
-            y=br.y - (self.size / 2),
-        )
+        centre = np.mean(self._pixel_corners, axis=0)
+        return PixelCoordinates(x=centre[0], y=centre[1])
 
     @cached_property
     def distance(self) -> int:


### PR DESCRIPTION
Moves to using the [standard right-handed](https://en.wikipedia.org/wiki/Cartesian_coordinate_system#In_three_dimensions) coordinate system and spherical coordinates in [mathematical notation](https://mathworld.wolfram.com/SphericalCoordinates.html).

[Yaw, pitch and roll](https://en.wikipedia.org/wiki/Aircraft_principal_axes) are also corrected to their expected directions.

Setting the environment variable ZOLOTO_LEGACY_AXIS uses the axis as in version 0.9.0, except for yaw, pitch and roll which always follows their expected directions.

Builds upon https://github.com/RealOrangeOne/zoloto/pull/302.